### PR TITLE
[FIX] MemberDTO와 Member 엔티티의 column인 주소를 zipcode, 도로명, 상세주소로 세분화

### DIFF
--- a/src/main/java/com/ohdaesan/shallwepets/member/controller/MemberController.java
+++ b/src/main/java/com/ohdaesan/shallwepets/member/controller/MemberController.java
@@ -22,13 +22,9 @@ import java.util.NoSuchElementException;
 public class MemberController {
     private final MemberService memberService;
 
-    @GetMapping("/register")
-    public String register() { return "member/signup"; }
-
     // 회원가입 요청
     @PostMapping("/register")
     public ResponseEntity<ResponseDTO> signup(@RequestBody MemberDTO memberDTO) {
-        System.out.println(memberDTO);
         MemberDTO savedMemberDTO = memberService.register(memberDTO);
 
         return ResponseEntity

--- a/src/main/java/com/ohdaesan/shallwepets/member/domain/dto/MemberDTO.java
+++ b/src/main/java/com/ohdaesan/shallwepets/member/domain/dto/MemberDTO.java
@@ -18,11 +18,13 @@ public class MemberDTO {
     private String memberEmail;
     private String memberPhone;
     private String memberDob;
-    private String memberAddress;
+    private String memberZipcode;
+    private String memberRoadAddress;
+    private String memberDetailAddress;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
     private String status = "ACTIVATED";
     private String memberRole = "USER";
-    private String grade;
+    private String grade = "치와와";
     private Long imageNo;
 }

--- a/src/main/java/com/ohdaesan/shallwepets/member/domain/entity/Member.java
+++ b/src/main/java/com/ohdaesan/shallwepets/member/domain/entity/Member.java
@@ -27,7 +27,9 @@ public class Member {
     private String memberEmail;
     private String memberPhone;
     private String memberDob;
-    private String memberAddress;
+    private String memberZipcode;
+    private String memberRoadAddress;
+    private String memberDetailAddress;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
 


### PR DESCRIPTION
MemberDTO와 Member 엔티티의 column인 주소를 zipcode, 도로명, 상세주소로 세분화